### PR TITLE
Amaslows addv12mods

### DIFF
--- a/common/variables.tfv12
+++ b/common/variables.tfv12
@@ -1,0 +1,46 @@
+variable "tenancy" {}
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "region" {
+  default = "us-ashburn-1"
+}
+variable "compartment_ocid" {}
+# Configure the Oracle Cloud Infrastructure provider with an API Key
+
+provider "oci" {
+  tenancy_ocid = "${var.tenancy_ocid}"
+  user_ocid = "${var.user_ocid}"
+  fingerprint = "${var.fingerprint}"
+  private_key_path = "${var.private_key_path}"
+  region = "${var.region}"
+  #version = "~> 3.1.0"
+}
+
+# Remote Statefile
+terraform {
+  backend "s3" {
+    region                  = "us-ashburn-1"                                                         # or us-ashburn-1
+    bucket                  = "vault_tfstate"                                                        # Put the tenant name here
+    endpoint                = "https://sonpopsch1.compat.objectstorage.us-ashburn-1.oraclecloud.com" # This will be always the same
+    key                     = "common/terraform.tfstate"                                             # This should contain "[OCI_BUCKET_NAME]/[OBJECT_NAME]"
+    shared_credentials_file = "../../../sharedsecrets/credentials"
+
+    # All S3-specific validations are skipped:
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    force_path_style            = true
+  }
+}
+
+# Get a list of Availability Domains
+data "oci_identity_availability_domains" "ads" {
+  compartment_id = "${var.tenancy_ocid}"
+}
+
+# Output the result
+output "show-ads" {
+  value = "${data.oci_identity_availability_domains.ads.availability_domains}"
+}

--- a/common/variables.tfv12
+++ b/common/variables.tfv12
@@ -21,11 +21,11 @@ provider "oci" {
 # Remote Statefile
 terraform {
   backend "s3" {
-    region                  = "us-ashburn-1"                                                         # or us-ashburn-1
-    bucket                  = "vault_tfstate"                                                        # Put the tenant name here
-    endpoint                = "https://sonpopsch1.compat.objectstorage.us-ashburn-1.oraclecloud.com" # This will be always the same
-    key                     = "common/terraform.tfstate"                                             # This should contain "[OCI_BUCKET_NAME]/[OBJECT_NAME]"
-    shared_credentials_file = "../../../sharedsecrets/credentials"
+    region                  = "us-ashburn-1"                                                         
+    bucket                  = "oci-vault"                                                            
+    endpoint                = "https://TENANCY.compat.objectstorage.REGION.oraclecloud.com"          
+    key                     = "common/terraform.tfstate"                                             
+    shared_credentials_file = "/home/YOU/.aws/oci-creds"
 
     # All S3-specific validations are skipped:
     skip_region_validation      = true

--- a/iad/network/subnets.tfv12
+++ b/iad/network/subnets.tfv12
@@ -1,0 +1,45 @@
+variable "availability_domain" {
+  default = 3
+}
+
+/* 
+Because you can specify multiple security lists/subnet the security_list_ids value must be specified as a list in []'s.
+ See https://www.terraform.io/docs/configuration/syntax.html
+   
+Generally you wouldn't specify a subnet without first specifying a VCN. Once the VCN has been created you would get the vcn_id, route_table_id, and security_list_id(s) from that resource and use Terraform attributes below to populate those values.
+ See https://www.terraform.io/docs/configuration/interpolation.html
+ */
+
+resource "oci_core_subnet" "oci_vault" {
+  count = 3
+  #availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.availability_domain - 1],"name")}"
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[count.index],"name")}"
+  cidr_block          = "${format("10.0.%d.0/24", count.index + 1)}"
+  display_name        = "${format("oci_vault_subnet_%d", count.index + 1)}"
+  compartment_id      = data.terraform_remote_state.common.outputs.network_compartment
+  vcn_id              = "${oci_core_virtual_network.oci-vault-vcn1.id}"
+  security_list_ids   = ["${oci_core_virtual_network.oci-vault-vcn1.default_security_list_id}"]
+  route_table_id      = "${oci_core_virtual_network.oci-vault-vcn1.default_route_table_id}"
+  dhcp_options_id     = "${oci_core_virtual_network.oci-vault-vcn1.default_dhcp_options_id}"
+  dns_label           = "${format("vault%d", count.index + 1)}"
+}
+
+data "oci_identity_availability_domains" "ADs" {
+  compartment_id = data.terraform_remote_state.common.outputs.network_compartment
+}
+
+data "oci_core_subnets" "oci_vault_subnets" {
+    #Required
+    compartment_id = data.terraform_remote_state.common.outputs.network_compartment
+    vcn_id         = "${oci_core_virtual_network.oci-vault-vcn1.id}"
+
+    #Optional
+/*
+    display_name = "${var.subnet_display_name}"
+    state = "${var.subnet_state}"
+*/
+}
+
+output "subnets" {
+    value = "${data.oci_core_subnets.oci_vault_subnets.subnets}"
+}

--- a/iad/network/variables.tfv12
+++ b/iad/network/variables.tfv12
@@ -1,0 +1,66 @@
+variable "tenancy" {}
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "region" {
+  default = "us-ashburn-1"
+}
+variable "compartment_ocid" {}
+# Configure the Oracle Cloud Infrastructure provider with an API Key
+
+provider "oci" {
+  tenancy_ocid = "${var.tenancy_ocid}"
+  user_ocid = "${var.user_ocid}"
+  fingerprint = "${var.fingerprint}"
+  private_key_path = "${var.private_key_path}"
+  region = "${var.region}"
+  #version = "~> 3.1.0"
+}
+
+terraform {
+  backend "s3" {
+    region                  = "us-ashburn-1"                                                         
+    bucket                  = "oci-vault"                                                        
+    endpoint                = "https://TENANCY.compat.objectstorage.REGION.oraclecloud.com" 
+    key                     = "iad/network/terraform.tfstate"                                        
+    shared_credentials_file = /home/YOU/.aws/oci-creds"
+
+    # All S3-specific validations are skipped:
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    force_path_style            = true
+  }
+}
+
+# Get a list of Availability Domains
+data "oci_identity_availability_domains" "ads" {
+  compartment_id = "${var.tenancy_ocid}"
+}
+
+data "terraform_remote_state" "common" {
+  backend = "s3"
+  config = {
+    region                  = "us-ashburn-1"                                                         
+    bucket                  = "oci-vault"                                                        
+    endpoint                = "https://sonpopsch1.compat.objectstorage.us-ashburn-1.oraclecloud.com" 
+    key                     = "common/terraform.tfstate"                                             
+    shared_credentials_file = "https://TENANCY.compat.objectstorage.REGION.oraclecloud.com"
+
+    # All S3-specific validations are skipped:
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    force_path_style            = true
+  }
+}
+
+# Output the result
+output "show-ads" {
+  value = "${data.oci_identity_availability_domains.ads.availability_domains}"
+}
+
+output "vault_subnets" {
+  value = ["${oci_core_subnet.oci_vault.*.id}"]
+}

--- a/iad/network/vcn.tfv12
+++ b/iad/network/vcn.tfv12
@@ -1,0 +1,58 @@
+resource "oci_core_virtual_network" "oci-vault-vcn1" {
+  cidr_block     = "10.0.0.0/16"
+  dns_label      = "ocivault"
+  compartment_id = data.terraform_remote_state.common.outputs.network_compartment
+  display_name   = "oci-vault-vcn1"
+}
+
+resource "oci_core_internet_gateway" "oci-vault-ig1" {
+  compartment_id = data.terraform_remote_state.common.outputs.network_compartment
+  display_name   = "oci-vault-ig1"
+  vcn_id         = "${oci_core_virtual_network.oci-vault-vcn1.id}"
+}
+
+resource "oci_core_default_route_table" "oci-vault-default-route-table" {
+  manage_default_resource_id = "${oci_core_virtual_network.oci-vault-vcn1.default_route_table_id}"
+  display_name               = "oci-vault-default-route-table"
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = "${oci_core_internet_gateway.oci-vault-ig1.id}"
+  }
+}
+
+resource "oci_core_route_table" "oci-vault-route-table1" {
+  compartment_id = data.terraform_remote_state.common.outputs.network_compartment
+  vcn_id         = "${oci_core_virtual_network.oci-vault-vcn1.id}"
+  display_name   = "oci-vault-route-table1"
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = "${oci_core_internet_gateway.oci-vault-ig1.id}"
+  }
+}
+
+resource "oci_core_default_dhcp_options" "oci-vault-default-dhcp-options" {
+  manage_default_resource_id = "${oci_core_virtual_network.oci-vault-vcn1.default_dhcp_options_id}"
+  display_name               = "oci-vault-default-dhcp-options"
+
+  // required
+  options {
+    type        = "DomainNameServer"
+    server_type = "VcnLocalPlusInternet"
+  }
+}
+
+resource "oci_core_dhcp_options" "oci-vault-dhcp-options1" {
+  compartment_id = data.terraform_remote_state.common.outputs.network_compartment
+  vcn_id         = "${oci_core_virtual_network.oci-vault-vcn1.id}"
+  display_name   = "oci-vault-dhcp-options1"
+
+  // required
+  options {
+    type        = "DomainNameServer"
+    server_type = "VcnLocalPlusInternet"
+  }
+}

--- a/iad/vault/consul.tfv12
+++ b/iad/vault/consul.tfv12
@@ -1,0 +1,50 @@
+# consul nodes
+
+resource "oci_core_instance" "consul" {
+  count               = 5
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[lookup(var.consul_node_to_ad_map, count.index, 1) - 1],"name")}"
+  compartment_id      = data.terraform_remote_state.common.outputs.vault_compartment
+  display_name        = "consul-${count.index}"
+  shape               = "${var.instance_shape}"
+
+  create_vnic_details {
+    subnet_id        = data.terraform_remote_state.network.outputs.vault_subnets[0][lookup(var.consul_node_to_ad_map, count.index, 1) - 1]
+    display_name     = "primaryvnic"
+    assign_public_ip = true
+    hostname_label   = "consul-${count.index}"
+  }
+
+  source_details {
+    source_type = "image"
+    source_id   = "${var.instance_image_ocid}"
+
+    # Apply this to set the size of the boot volume that's created for this instance.
+    # Otherwise, the default boot volume size of the image is used.
+    # This should only be specified when source_type is set to "image".
+    #boot_volume_size_in_gbs = "60"
+  }
+
+  # Apply the following flag only if you wish to preserve the attached boot volume upon destroying this instance
+  # Setting this and destroying the instance will result in a boot volume that should be managed outside of this config.
+  # When changing this value, make sure to run 'terraform apply' so that it takes effect before the resource is destroyed.
+  #preserve_boot_volume = true
+
+  metadata = {
+    ssh_authorized_keys = "${file(var.ssh_public_key)}"
+    user_data           = "${base64encode(file("${path.module}/user-data/consul.txt"))}"
+  }
+
+  freeform_tags = "${map("consul-server", "freeformvalue${count.index}")}"
+
+  timeouts {
+    create = "60m"
+  }
+}
+
+output "consul_instances" {
+ value = ["${oci_core_instance.consul.*.id}"]
+}
+
+output "consul_instance_public_ips" {
+ value = ["${oci_core_instance.consul.*.public_ip}"]
+}

--- a/iad/vault/variables.tfv12
+++ b/iad/vault/variables.tfv12
@@ -1,0 +1,104 @@
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "compartment_ocid" {}
+variable "region" {
+  default = "us-ashburn-1"
+}
+variable "ssh_public_key" {
+  default = "PATH TO YOUR SSH PUBLIC KEY FOR SSH ACCESS"
+}
+variable "consul_node_to_ad_map" {
+  type = "map"
+
+  default = {
+    "0" = "1"
+    "1" = "1"
+    "2" = "2"
+    "3" = "3"
+    "4" = "3"
+  }
+}
+variable "instance_image_ocid" {
+  # oci compute image list --compartment-id ocid1.compartment.oc1..derp | jq '.data[] | select(."display-name"=="CentOS-7-2018.10.12-0")'
+  default = "ocid1.image.oc1.iad.aaaaaaaavujqgegoqyinkxzigumlwydq42vyf6nr3sfl7ram577zzlz2clpa"
+}
+
+variable "instance_shape" {
+  default = "VM.Standard2.1"
+}
+
+provider "oci" {
+  tenancy_ocid     = "${var.tenancy_ocid}"
+  user_ocid        = "${var.user_ocid}"
+  fingerprint      = "${var.fingerprint}"
+  private_key_path = "${var.private_key_path}"
+  region           = "${var.region}"
+  #version          = "~> 3.1.0"
+}
+
+# Configure the Oracle Cloud Infrastructure provider with an API Key
+terraform {
+  backend "s3" {
+    region                  = "us-ashburn-1"                                                         
+    bucket                  = "oci-vault"                                                  
+    endpoint                = "https://TENANCY.compat.objectstorage.REGION.oraclecloud.com"
+    key                     = "iad/vault/terraform.tfstate"                                
+    shared_credentials_file = "/home/YOU/.aws/oci-creds"
+
+    # All S3-specific validations are skipped:
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    force_path_style            = true
+  }
+}
+
+# Get a list of Availability Domains
+data "oci_identity_availability_domains" "ads" {
+  compartment_id = "${var.tenancy_ocid}"
+}
+
+data "terraform_remote_state" "common" {
+  backend = "s3"
+  config = {
+    region                  = "us-ashburn-1"                                                
+    bucket                  = "oci-vault"                                                   
+    endpoint                = "https://TENANCY.compat.objectstorage.REGION.oraclecloud.com" 
+    key                     = "common/terraform.tfstate"                                             
+    shared_credentials_file = "/home/YOU/.aws/oci-creds"
+
+    # All S3-specific validations are skipped:
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    force_path_style            = true
+  }
+}
+
+data "terraform_remote_state" "network" {
+  backend = "s3"
+  config = {
+    region                  = "us-ashburn-1"                                                        
+    bucket                  = "oci-vault"                                                       
+    endpoint                = "https://TENANCY.compat.objectstorage.REGION.oraclecloud.com"
+    key                     = "iad/network/terraform.tfstate"                                       
+    shared_credentials_file = "/home/YOU/.aws/oci-creds"
+
+    # All S3-specific validations are skipped:
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    force_path_style            = true
+  }
+}
+
+data "oci_identity_availability_domains" "ADs" {
+  compartment_id = data.terraform_remote_state.common.outputs.vault_compartment
+}
+
+# Output the result
+output "show-ads" {
+  value = "${data.oci_identity_availability_domains.ads.availability_domains}"
+}

--- a/iad/vault/vault.tf
+++ b/iad/vault/vault.tf
@@ -4,7 +4,7 @@ resource "oci_core_instance" "vault" {
   count               = 3
   availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[count.index],"name")}"
   compartment_id      = "${data.terraform_remote_state.common.vault_compartment}"
-  display_name        = "consul-${count.index}"
+  display_name        = "vault-${count.index}"
   shape               = "${var.instance_shape}"
 
   create_vnic_details {

--- a/iad/vault/vault.tfv12
+++ b/iad/vault/vault.tfv12
@@ -1,0 +1,50 @@
+# vault nodes
+
+resource "oci_core_instance" "vault" {
+  count               = 3
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[count.index],"name")}"
+  compartment_id      = data.terraform_remote_state.common.outputs.vault_compartment
+  display_name        = "vault-${count.index}"
+  shape               = "${var.instance_shape}"
+
+  create_vnic_details {
+    subnet_id        = data.terraform_remote_state.network.outputs.vault_subnets[0][count.index]
+    display_name     = "primaryvnic"
+    assign_public_ip = true
+    hostname_label   = "vault-${count.index}"
+  }
+
+  source_details {
+    source_type = "image"
+    source_id   = "${var.instance_image_ocid}"
+
+    # Apply this to set the size of the boot volume that's created for this instance.
+    # Otherwise, the default boot volume size of the image is used.
+    # This should only be specified when source_type is set to "image".
+    #boot_volume_size_in_gbs = "60"
+  }
+
+  # Apply the following flag only if you wish to preserve the attached boot volume upon destroying this instance
+  # Setting this and destroying the instance will result in a boot volume that should be managed outside of this config.
+  # When changing this value, make sure to run 'terraform apply' so that it takes effect before the resource is destroyed.
+  #preserve_boot_volume = true
+
+  metadata = {
+    ssh_authorized_keys = "${file(var.ssh_public_key)}"
+    user_data           = "${base64encode(file("${path.module}/user-data/vault.txt"))}"
+  }
+
+  freeform_tags = "${map("vault-server", "freeformvalue${count.index}")}"
+  
+  timeouts {
+    create = "60m"
+  }
+}
+
+output "vault_instances" {
+ value = ["${oci_core_instance.vault.*.id}"]
+}
+
+output "vault_instance_public_ips" {
+ value = ["${oci_core_instance.vault.*.public_ip}"]
+}


### PR DESCRIPTION
Summary of changes:

Errata: 
- vault.tf - fixed the display_name to vault from consul (last change was only on vnic label)

v12 Changes:
- all variables.tf files 
    - commented 3.1.0 oci reference (incompat with v12), terraform init will pull latest compat oci provider
    - fixed any remote_state references to new syntax with outputs leve
    - removed a couple S3 skip settings that are deprecated
- all other tf files
    - updated to new remote_state datasource syntax with outputs level
    - fixed vault_subnets datasource to include an extra [] for the new tuple level in the datasource